### PR TITLE
Implement deposit opening flow with Axon and Camunda

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>3.5.5</version>
+        <version>3.2.5</version>
         <relativePath/> <!-- lookup parent from repository -->
     </parent>
     <groupId>com.arch</groupId>
@@ -29,16 +29,65 @@
     <properties>
         <java.version>21</java.version>
     </properties>
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>org.springframework.cloud</groupId>
+                <artifactId>spring-cloud-dependencies</artifactId>
+                <version>2023.0.1</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
     <dependencies>
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter</artifactId>
         </dependency>
 
+        <!-- Camunda 8 Zeebe client -->
+        <dependency>
+            <groupId>io.camunda</groupId>
+            <artifactId>spring-boot-starter-camunda-sdk</artifactId>
+            <version>8.7.0</version>
+        </dependency>
+
+        <!-- Axon Framework for CQRS/Event Sourcing -->
+        <dependency>
+            <groupId>org.axonframework</groupId>
+            <artifactId>axon-spring-boot-starter</artifactId>
+            <version>4.9.1</version>
+        </dependency>
+
+        <!-- Data access -->
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-data-jpa</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.h2database</groupId>
+            <artifactId>h2</artifactId>
+            <scope>runtime</scope>
+        </dependency>
+
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-test</artifactId>
             <scope>test</scope>
+        </dependency>
+
+        <!-- OpenFeign client for Core banking integration -->
+        <dependency>
+            <groupId>org.springframework.cloud</groupId>
+            <artifactId>spring-cloud-starter-openfeign</artifactId>
+        </dependency>
+
+        <!-- Lombok for reducing boilerplate code -->
+        <dependency>
+            <groupId>org.projectlombok</groupId>
+            <artifactId>lombok</artifactId>
+            <optional>true</optional>
         </dependency>
     </dependencies>
 

--- a/src/main/java/com/arch/deposit/DepositApplication.java
+++ b/src/main/java/com/arch/deposit/DepositApplication.java
@@ -2,8 +2,10 @@ package com.arch.deposit;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.cloud.openfeign.EnableFeignClients;
 
 @SpringBootApplication
+@EnableFeignClients
 public class DepositApplication {
 
     public static void main(String[] args) {

--- a/src/main/java/com/arch/deposit/aggregate/DepositAggregate.java
+++ b/src/main/java/com/arch/deposit/aggregate/DepositAggregate.java
@@ -1,0 +1,57 @@
+package com.arch.deposit.aggregate;
+
+import com.arch.deposit.command.SelectDepositTypeCommand;
+import com.arch.deposit.command.StartDepositOpeningCommand;
+import com.arch.deposit.event.DepositOpeningStartedEvent;
+import com.arch.deposit.event.DepositTypeSelectedEvent;
+
+import java.util.UUID;
+
+import org.axonframework.commandhandling.CommandHandler;
+import org.axonframework.modelling.command.AggregateIdentifier;
+import org.axonframework.modelling.command.AggregateLifecycle;
+import org.axonframework.spring.stereotype.Aggregate;
+import org.axonframework.eventsourcing.EventSourcingHandler;
+
+/** Aggregate representing the lifecycle of a deposit opening. */
+@Aggregate
+public class DepositAggregate {
+
+    @AggregateIdentifier
+    private String depositId;
+    private String userId;
+    private UUID depositTypeId;
+    private boolean started;
+
+    protected DepositAggregate() {
+        // Axon requires a no-arg constructor
+    }
+
+    @CommandHandler
+    public DepositAggregate(SelectDepositTypeCommand cmd) {
+        AggregateLifecycle.apply(new DepositTypeSelectedEvent(
+                cmd.depositId(), cmd.userId(), cmd.depositTypeId()));
+    }
+
+    @EventSourcingHandler
+    public void on(DepositTypeSelectedEvent event) {
+        this.depositId = event.depositId();
+        this.userId = event.userId();
+        this.depositTypeId = event.depositTypeId();
+        this.started = false;
+    }
+
+    @CommandHandler
+    public void handle(StartDepositOpeningCommand cmd) {
+        if (started) {
+            throw new IllegalStateException("Deposit already started");
+        }
+        AggregateLifecycle.apply(new DepositOpeningStartedEvent(cmd.depositId()));
+    }
+
+    @EventSourcingHandler
+    public void on(DepositOpeningStartedEvent event) {
+        this.started = true;
+    }
+}
+

--- a/src/main/java/com/arch/deposit/command/SelectDepositTypeCommand.java
+++ b/src/main/java/com/arch/deposit/command/SelectDepositTypeCommand.java
@@ -1,0 +1,13 @@
+package com.arch.deposit.command;
+
+import java.util.UUID;
+
+import org.axonframework.modelling.command.TargetAggregateIdentifier;
+
+/** Command to create a deposit aggregate by selecting a deposit type. */
+public record SelectDepositTypeCommand(
+        @TargetAggregateIdentifier String depositId,
+        String userId,
+        UUID depositTypeId
+) {}
+

--- a/src/main/java/com/arch/deposit/command/StartDepositOpeningCommand.java
+++ b/src/main/java/com/arch/deposit/command/StartDepositOpeningCommand.java
@@ -1,0 +1,9 @@
+package com.arch.deposit.command;
+
+import org.axonframework.modelling.command.TargetAggregateIdentifier;
+
+/** Command to signal that the user started the deposit opening. */
+public record StartDepositOpeningCommand(
+        @TargetAggregateIdentifier String depositId
+) {}
+

--- a/src/main/java/com/arch/deposit/controller/DepositController.java
+++ b/src/main/java/com/arch/deposit/controller/DepositController.java
@@ -1,0 +1,48 @@
+package com.arch.deposit.controller;
+
+import java.util.List;
+
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.UUID;
+
+import com.arch.deposit.deposittype.DepositType;
+import com.arch.deposit.deposittype.DepositTypeRepository;
+import com.arch.deposit.service.DepositService;
+
+/** REST endpoints for the deposit opening flow. */
+@RestController
+@RequestMapping("/api/deposits")
+public class DepositController {
+
+    private final DepositTypeRepository typeRepository;
+    private final DepositService depositService;
+
+    public DepositController(DepositTypeRepository typeRepository, DepositService depositService) {
+        this.typeRepository = typeRepository;
+        this.depositService = depositService;
+    }
+
+    /** Returns available deposit types. */
+    @GetMapping("/types")
+    public List<DepositType> listTypes() {
+        return typeRepository.findAll();
+    }
+
+    /** Step 1 – user selects a deposit type, starting the process. */
+    @PostMapping("/{userId}/types/{typeId}")
+    public String selectDepositType(@PathVariable String userId, @PathVariable UUID typeId) {
+        return depositService.selectDepositType(userId, typeId);
+    }
+
+    /** Step 3 – user starts opening the previously selected deposit. */
+    @PostMapping("/{userId}/{depositId}/start")
+    public void startOpening(@PathVariable String userId, @PathVariable String depositId) {
+        depositService.startDepositOpening(userId, depositId);
+    }
+}
+

--- a/src/main/java/com/arch/deposit/core/CoreClient.java
+++ b/src/main/java/com/arch/deposit/core/CoreClient.java
@@ -1,0 +1,16 @@
+package com.arch.deposit.core;
+
+import java.util.List;
+
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.web.bind.annotation.GetMapping;
+
+/**
+ * Feign client for retrieving deposit types from the core banking service.
+ */
+@FeignClient(name = "core-client", url = "${core.service.url}")
+public interface CoreClient {
+
+    @GetMapping("/api/corebanking/deposits/v1.0/types")
+    List<CoreDepositTypeDTO> getDepositTypes();
+}

--- a/src/main/java/com/arch/deposit/core/CoreDepositTypeDTO.java
+++ b/src/main/java/com/arch/deposit/core/CoreDepositTypeDTO.java
@@ -1,0 +1,6 @@
+package com.arch.deposit.core;
+
+import java.util.UUID;
+
+/** DTO representing a deposit type returned by the core banking service. */
+public record CoreDepositTypeDTO(UUID id, String name, String description) {}

--- a/src/main/java/com/arch/deposit/deposittype/DepositType.java
+++ b/src/main/java/com/arch/deposit/deposittype/DepositType.java
@@ -1,0 +1,33 @@
+package com.arch.deposit.deposittype;
+
+import java.util.UUID;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+/**
+ * JPA entity representing a selectable type of deposit.
+ * The same entity is used for both reading and writing.
+ */
+@Entity
+@Table(name = "\"deposit\"")
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class DepositType {
+
+    @Id
+    @Column(name = "id", updatable = false, nullable = false, unique = true)
+    private UUID id;
+
+    private String name;
+    private String description;
+}
+

--- a/src/main/java/com/arch/deposit/deposittype/DepositTypeRepository.java
+++ b/src/main/java/com/arch/deposit/deposittype/DepositTypeRepository.java
@@ -1,0 +1,10 @@
+package com.arch.deposit.deposittype;
+
+import java.util.UUID;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+/** Repository for available deposit types. */
+public interface DepositTypeRepository extends JpaRepository<DepositType, UUID> {
+}
+

--- a/src/main/java/com/arch/deposit/deposittype/DepositTypeSyncService.java
+++ b/src/main/java/com/arch/deposit/deposittype/DepositTypeSyncService.java
@@ -1,0 +1,42 @@
+package com.arch.deposit.deposittype;
+
+import java.util.List;
+
+import org.springframework.boot.CommandLineRunner;
+import org.springframework.stereotype.Component;
+
+import com.arch.deposit.core.CoreClient;
+import com.arch.deposit.core.CoreDepositTypeDTO;
+
+/**
+ * Synchronizes deposit types from the core banking service into the local
+ * repository for faster access.
+ */
+@Component
+class DepositTypeSyncService implements CommandLineRunner {
+
+    private final CoreClient coreClient;
+    private final DepositTypeRepository repository;
+
+    DepositTypeSyncService(CoreClient coreClient, DepositTypeRepository repository) {
+        this.coreClient = coreClient;
+        this.repository = repository;
+    }
+
+    @Override
+    public void run(String... args) {
+        refreshFromCore();
+    }
+
+    void refreshFromCore() {
+        List<CoreDepositTypeDTO> types = coreClient.getDepositTypes();
+        List<DepositType> entities = types.stream()
+                .map(dto -> DepositType.builder()
+                        .id(dto.id())
+                        .name(dto.name())
+                        .description(dto.description())
+                        .build())
+                .toList();
+        repository.saveAll(entities);
+    }
+}

--- a/src/main/java/com/arch/deposit/event/DepositOpeningStartedEvent.java
+++ b/src/main/java/com/arch/deposit/event/DepositOpeningStartedEvent.java
@@ -1,0 +1,7 @@
+package com.arch.deposit.event;
+
+/** Event emitted when the deposit opening is started. */
+public record DepositOpeningStartedEvent(
+        String depositId
+) {}
+

--- a/src/main/java/com/arch/deposit/event/DepositTypeSelectedEvent.java
+++ b/src/main/java/com/arch/deposit/event/DepositTypeSelectedEvent.java
@@ -1,0 +1,11 @@
+package com.arch.deposit.event;
+
+import java.util.UUID;
+
+/** Event emitted when a user selects a deposit type. */
+public record DepositTypeSelectedEvent(
+        String depositId,
+        String userId,
+        UUID depositTypeId
+) {}
+

--- a/src/main/java/com/arch/deposit/service/DepositService.java
+++ b/src/main/java/com/arch/deposit/service/DepositService.java
@@ -1,0 +1,70 @@
+package com.arch.deposit.service;
+
+import java.util.Map;
+import java.util.UUID;
+
+import org.axonframework.commandhandling.gateway.CommandGateway;
+import org.springframework.stereotype.Service;
+
+import com.arch.deposit.command.SelectDepositTypeCommand;
+import com.arch.deposit.command.StartDepositOpeningCommand;
+
+import io.camunda.zeebe.client.ZeebeClient;
+
+/**
+ * Application service orchestrating commands to Axon and messages to Camunda.
+ */
+@Service
+public class DepositService {
+
+    private final CommandGateway commandGateway;
+    private final ZeebeClient zeebeClient;
+
+    public DepositService(CommandGateway commandGateway,
+                          ZeebeClient zeebeClient) {
+        this.commandGateway = commandGateway;
+        this.zeebeClient = zeebeClient;
+    }
+
+    /**
+     * First step: user selects a deposit type. We create the deposit aggregate,
+     * start a BPMN process instance, and publish the message that moves the
+     * process to the next step.
+     *
+     * @return the generated deposit identifier
+     */
+    public String selectDepositType(String userId, UUID depositTypeId) {
+        String depositId = UUID.randomUUID().toString();
+
+        commandGateway.sendAndWait(new SelectDepositTypeCommand(depositId, userId, depositTypeId));
+
+        zeebeClient.newCreateInstanceCommand()
+                .bpmnProcessId("Process_182eqvi")
+                .latestVersion()
+                .variables(Map.of("userID", userId, "depositId", depositId))
+                .send()
+                .join();
+
+        zeebeClient.newPublishMessageCommand()
+                .messageName("select-deposit-type")
+                .correlationKey(userId)
+                .variables(Map.of("depositId", depositId, "depositTypeId", depositTypeId.toString()))
+                .send()
+                .join();
+
+        return depositId;
+    }
+
+    /** Third step: user confirms starting the deposit opening. */
+    public void startDepositOpening(String userId, String depositId) {
+        commandGateway.sendAndWait(new StartDepositOpeningCommand(depositId));
+
+        zeebeClient.newPublishMessageCommand()
+                .messageName("start-deposit-opening")
+                .correlationKey(userId)
+                .variables(Map.of("depositId", depositId))
+                .send()
+                .join();
+    }
+}
+

--- a/src/main/java/com/arch/deposit/worker/DisplayDepositsWorker.java
+++ b/src/main/java/com/arch/deposit/worker/DisplayDepositsWorker.java
@@ -1,0 +1,31 @@
+package com.arch.deposit.worker;
+
+import java.util.Map;
+
+import org.springframework.stereotype.Component;
+
+import com.arch.deposit.deposittype.DepositTypeRepository;
+
+import io.camunda.zeebe.client.api.response.ActivatedJob;
+import io.camunda.zeebe.spring.client.annotation.JobWorker;
+
+/**
+ * Worker invoked by the BPMN service task "Display user deposits". It now
+ * returns the available deposit types so the UI can present them for selection.
+ */
+@Component
+public class DisplayDepositsWorker {
+
+    private final DepositTypeRepository repository;
+
+    public DisplayDepositsWorker(DepositTypeRepository repository) {
+        this.repository = repository;
+    }
+
+    @JobWorker(type = "display-user-deposits")
+    public Map<String, Object> handle(final ActivatedJob job) {
+        // return all available deposit types for selection
+        return Map.of("depositTypes", repository.findAll());
+    }
+}
+

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,1 +1,17 @@
 spring.application.name=deposit
+
+# In-memory H2 database for projections and deposit types
+spring.datasource.url=jdbc:h2:mem:deposit;DB_CLOSE_DELAY=-1
+spring.datasource.driverClassName=org.h2.Driver
+spring.jpa.hibernate.ddl-auto=update
+spring.h2.console.enabled=true
+
+# Axon without AxonServer
+axon.axonserver.enabled=false
+
+# Zeebe connection (adjust if necessary)
+zeebe.client.gateway-address=127.0.0.1:26500
+zeebe.client.plaintext=true
+
+# Core banking service base URL for deposit types
+core.service.url=http://192.168.179.20:8290


### PR DESCRIPTION
## Summary
- Use UUID-based DepositType entity for both reading and writing
- Update commands, events, aggregate and services to accept UUID deposit type IDs
- Configure Maven parent and Lombok dependency
- Remove deposit view projection and rely solely on DepositType
- Fetch deposit types from Core banking via Feign on startup

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM due to network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68bbf8f9e27c832698e27ef2d653dec2