### PR TITLE
Implement deposit opening flow with Axon and Camunda

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>3.5.5</version>
+        <version>3.2.5</version>
         <relativePath/> <!-- lookup parent from repository -->
     </parent>
     <groupId>com.arch</groupId>
@@ -29,10 +29,46 @@
     <properties>
         <java.version>21</java.version>
     </properties>
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>org.springframework.cloud</groupId>
+                <artifactId>spring-cloud-dependencies</artifactId>
+                <version>2023.0.1</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
     <dependencies>
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter</artifactId>
+        </dependency>
+
+        <!-- Camunda 8 Zeebe client -->
+        <dependency>
+            <groupId>io.camunda</groupId>
+            <artifactId>spring-boot-starter-camunda-sdk</artifactId>
+            <version>8.7.0</version>
+        </dependency>
+
+        <!-- Axon Framework for CQRS/Event Sourcing -->
+        <dependency>
+            <groupId>org.axonframework</groupId>
+            <artifactId>axon-spring-boot-starter</artifactId>
+            <version>4.9.1</version>
+        </dependency>
+
+        <!-- Data access -->
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-data-jpa</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.h2database</groupId>
+            <artifactId>h2</artifactId>
+            <scope>runtime</scope>
         </dependency>
 
         <dependency>
@@ -40,15 +76,40 @@
             <artifactId>spring-boot-starter-test</artifactId>
             <scope>test</scope>
         </dependency>
+
+        <!-- OpenFeign client for Core banking integration -->
+        <dependency>
+            <groupId>org.springframework.cloud</groupId>
+            <artifactId>spring-cloud-starter-openfeign</artifactId>
+        </dependency>
+
+        <!-- Lombok for reducing boilerplate code -->
+        <dependency>
+            <groupId>org.projectlombok</groupId>
+            <artifactId>lombok</artifactId>
+            <optional>true</optional>
+        </dependency>
     </dependencies>
 
-    <build>
-        <plugins>
-            <plugin>
-                <groupId>org.springframework.boot</groupId>
-                <artifactId>spring-boot-maven-plugin</artifactId>
-            </plugin>
-        </plugins>
-    </build>
+      <build>
+          <plugins>
+              <plugin>
+                  <groupId>org.apache.maven.plugins</groupId>
+                  <artifactId>maven-compiler-plugin</artifactId>
+                  <configuration>
+                      <annotationProcessorPaths>
+                          <path>
+                              <groupId>org.projectlombok</groupId>
+                              <artifactId>lombok</artifactId>
+                          </path>
+                      </annotationProcessorPaths>
+                  </configuration>
+              </plugin>
+              <plugin>
+                  <groupId>org.springframework.boot</groupId>
+                  <artifactId>spring-boot-maven-plugin</artifactId>
+              </plugin>
+          </plugins>
+      </build>
 
 </project>

--- a/src/main/java/com/arch/deposit/DepositApplication.java
+++ b/src/main/java/com/arch/deposit/DepositApplication.java
@@ -2,8 +2,10 @@ package com.arch.deposit;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.cloud.openfeign.EnableFeignClients;
 
 @SpringBootApplication
+@EnableFeignClients
 public class DepositApplication {
 
     public static void main(String[] args) {

--- a/src/main/java/com/arch/deposit/account/Deposit.java
+++ b/src/main/java/com/arch/deposit/account/Deposit.java
@@ -1,0 +1,50 @@
+package com.arch.deposit.account;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+/**
+ * Represents a deposit account retrieved from the core banking system.
+ */
+@Entity
+@Table(name = "deposit_account")
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class Deposit {
+
+    @Id
+    private String depositNumber;
+
+    private String mainCustomerNumber;
+    private String depositTitle;
+    private String depositTypeNumber;
+    private String depositTypeTitle;
+    private String depositState;
+    private String currencyName;
+    private String currencySwiftCode;
+    private String withdrawRight;
+    private String branchCode;
+    private String depositIban;
+    private String availableAmount;
+    private String openingDate;
+    private String portion;
+    private String isSpecial;
+    private String fullName;
+    private String individualOrSharedDeposit;
+    private String actualAmount;
+    private String depositRight;
+    private String englishIndividualOrSharedDeposit;
+    private String depositIdentity;
+    private String depositIdentityCode;
+    private String withdrawRightWithCheque;
+    private String depositTypeTreeRoot;
+    private String depositTypeTreeRootCode;
+}
+

--- a/src/main/java/com/arch/deposit/account/DepositRepository.java
+++ b/src/main/java/com/arch/deposit/account/DepositRepository.java
@@ -1,0 +1,11 @@
+package com.arch.deposit.account;
+
+import java.util.List;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface DepositRepository extends JpaRepository<Deposit, String> {
+    List<Deposit> findByMainCustomerNumber(String mainCustomerNumber);
+    void deleteByMainCustomerNumber(String mainCustomerNumber);
+}
+

--- a/src/main/java/com/arch/deposit/account/UserDepositSyncService.java
+++ b/src/main/java/com/arch/deposit/account/UserDepositSyncService.java
@@ -1,0 +1,67 @@
+package com.arch.deposit.account;
+
+import java.util.List;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.arch.deposit.core.CoreClient;
+import com.arch.deposit.core.CoreDepositDTO;
+
+import lombok.RequiredArgsConstructor;
+
+/**
+ * Synchronizes user deposit accounts with the core banking system.
+ */
+@Service
+@RequiredArgsConstructor
+public class UserDepositSyncService {
+
+    private final CoreClient coreClient;
+    private final DepositRepository repository;
+
+    /**
+     * Refresh deposits for the given customer by pulling data from the core
+     * service and storing it locally.
+     */
+    @Transactional
+    public List<Deposit> refresh(String customerNumber) {
+        List<CoreDepositDTO> dtos = coreClient.getDepositsForCustomer(customerNumber);
+        repository.deleteByMainCustomerNumber(customerNumber);
+        List<Deposit> deposits = dtos.stream()
+                .map(dto -> Deposit.builder()
+                        .depositNumber(dto.getDepositNumber())
+                        .mainCustomerNumber(dto.getMainCustomerNumber())
+                        .depositTitle(dto.getDepositTitle())
+                        .depositTypeNumber(dto.getDepositTypeNumber())
+                        .depositTypeTitle(dto.getDepositTypeTitle())
+                        .depositState(dto.getDepositState())
+                        .currencyName(dto.getCurrencyName())
+                        .currencySwiftCode(dto.getCurrencySwiftCode())
+                        .withdrawRight(dto.getWithdrawRight())
+                        .branchCode(dto.getBranchCode())
+                        .depositIban(dto.getDepositIban())
+                        .availableAmount(dto.getAvailableAmount())
+                        .openingDate(dto.getOpeningDate())
+                        .portion(dto.getPortion())
+                        .isSpecial(dto.getIsSpecial())
+                        .fullName(dto.getFullName())
+                        .individualOrSharedDeposit(dto.getIndividualOrSharedDeposit())
+                        .actualAmount(dto.getActualAmount())
+                        .depositRight(dto.getDepositRight())
+                        .englishIndividualOrSharedDeposit(dto.getEnglishIndividualOrSharedDeposit())
+                        .depositIdentity(dto.getDepositIdentity())
+                        .depositIdentityCode(dto.getDepositIdentityCode())
+                        .withdrawRightWithCheque(dto.getWithdrawRightWithCheque())
+                        .depositTypeTreeRoot(dto.getDepositTypeTreeRoot())
+                        .depositTypeTreeRootCode(dto.getDepositTypeTreeRootCode())
+                        .build())
+                .toList();
+        return repository.saveAll(deposits);
+    }
+
+    public List<Deposit> findByCustomer(String customerNumber) {
+        return repository.findByMainCustomerNumber(customerNumber);
+    }
+}
+

--- a/src/main/java/com/arch/deposit/aggregate/DepositAggregate.java
+++ b/src/main/java/com/arch/deposit/aggregate/DepositAggregate.java
@@ -1,0 +1,53 @@
+package com.arch.deposit.aggregate;
+
+import com.arch.deposit.command.SelectDepositTypeCommand;
+import com.arch.deposit.command.StartDepositOpeningCommand;
+import com.arch.deposit.event.DepositOpeningStartedEvent;
+import com.arch.deposit.event.DepositTypeSelectedEvent;
+
+import java.util.UUID;
+
+import org.axonframework.commandhandling.CommandHandler;
+import org.axonframework.eventsourcing.EventSourcingHandler;
+import org.axonframework.modelling.command.AggregateIdentifier;
+import org.axonframework.modelling.command.AggregateLifecycle;
+import org.axonframework.spring.stereotype.Aggregate;
+
+/** Aggregate representing the lifecycle of a deposit opening. */
+@Aggregate
+public class DepositAggregate {
+
+    @AggregateIdentifier
+    private String depositId;
+    private String userId;
+    private UUID depositTypeId;
+
+    protected DepositAggregate() {
+        // Axon requires a no-arg constructor
+    }
+
+    @CommandHandler
+    public DepositAggregate(StartDepositOpeningCommand cmd) {
+        AggregateLifecycle.apply(new DepositOpeningStartedEvent(cmd.depositId(), cmd.userId()));
+    }
+
+    @EventSourcingHandler
+    public void on(DepositOpeningStartedEvent event) {
+        this.depositId = event.depositId();
+        this.userId = event.userId();
+    }
+
+    @CommandHandler
+    public void handle(SelectDepositTypeCommand cmd) {
+        if (this.depositTypeId != null) {
+            throw new IllegalStateException("Deposit type already selected");
+        }
+        AggregateLifecycle.apply(new DepositTypeSelectedEvent(cmd.depositId(), cmd.depositTypeId()));
+    }
+
+    @EventSourcingHandler
+    public void on(DepositTypeSelectedEvent event) {
+        this.depositTypeId = event.depositTypeId();
+    }
+}
+

--- a/src/main/java/com/arch/deposit/command/SelectDepositTypeCommand.java
+++ b/src/main/java/com/arch/deposit/command/SelectDepositTypeCommand.java
@@ -1,0 +1,12 @@
+package com.arch.deposit.command;
+
+import java.util.UUID;
+
+import org.axonframework.modelling.command.TargetAggregateIdentifier;
+
+/** Command to choose a deposit type after the process has started. */
+public record SelectDepositTypeCommand(
+        @TargetAggregateIdentifier String depositId,
+        UUID depositTypeId
+) {}
+

--- a/src/main/java/com/arch/deposit/command/StartDepositOpeningCommand.java
+++ b/src/main/java/com/arch/deposit/command/StartDepositOpeningCommand.java
@@ -1,0 +1,10 @@
+package com.arch.deposit.command;
+
+import org.axonframework.modelling.command.TargetAggregateIdentifier;
+
+/** Command to create a deposit aggregate when the user starts the flow. */
+public record StartDepositOpeningCommand(
+        @TargetAggregateIdentifier String depositId,
+        String userId
+) {}
+

--- a/src/main/java/com/arch/deposit/controller/DepositController.java
+++ b/src/main/java/com/arch/deposit/controller/DepositController.java
@@ -1,0 +1,61 @@
+package com.arch.deposit.controller;
+
+import java.util.List;
+
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.UUID;
+
+import com.arch.deposit.account.Deposit;
+import com.arch.deposit.account.UserDepositSyncService;
+import com.arch.deposit.deposittype.DepositType;
+import com.arch.deposit.deposittype.DepositTypeSyncService;
+import com.arch.deposit.service.DepositService;
+
+/** REST endpoints for the deposit opening flow. */
+@RestController
+@RequestMapping("/api/deposits")
+public class DepositController {
+
+    private final DepositService depositService;
+    private final DepositTypeSyncService typeSyncService;
+    private final UserDepositSyncService depositSyncService;
+
+    public DepositController(DepositService depositService,
+                             DepositTypeSyncService typeSyncService,
+                             UserDepositSyncService depositSyncService) {
+        this.depositService = depositService;
+        this.typeSyncService = typeSyncService;
+        this.depositSyncService = depositSyncService;
+    }
+
+    /** Step 1 – user starts the deposit opening flow. */
+    @PostMapping("/{userId}/start")
+    public StartResponse start(@PathVariable String userId) {
+        String depositId = depositService.startDepositOpening(userId);
+        List<DepositType> types = typeSyncService.syncAndReturnAll();
+        return new StartResponse(depositId, types);
+    }
+
+    /** Step 2 – user selects a deposit type. */
+    @PostMapping("/{userId}/{depositId}/types/{typeId}")
+    public void selectDepositType(@PathVariable String userId,
+                                  @PathVariable String depositId,
+                                  @PathVariable UUID typeId) {
+        depositService.selectDepositType(userId, depositId, typeId);
+    }
+
+    /** Retrieve and store user deposit accounts from core banking. */
+    @GetMapping("/{userId}/accounts")
+    public List<Deposit> listUserDeposits(@PathVariable String userId) {
+        return depositSyncService.refresh(userId);
+    }
+
+    /** Response returned when the flow is started. */
+    public record StartResponse(String depositId, List<DepositType> depositTypes) {}
+}
+

--- a/src/main/java/com/arch/deposit/core/CoreClient.java
+++ b/src/main/java/com/arch/deposit/core/CoreClient.java
@@ -1,0 +1,23 @@
+package com.arch.deposit.core;
+
+import java.util.List;
+
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+
+/**
+ * Feign client for retrieving deposit types from the core banking service.
+ */
+@FeignClient(name = "core-client", url = "${core.service.url}")
+public interface CoreClient {
+
+    @GetMapping("/api/corebanking/deposits/v1.0/types")
+    List<CoreDepositTypeDTO> getDepositTypes();
+
+    /**
+     * Retrieve deposit accounts for a given customer from the core banking system.
+     */
+    @GetMapping("/api/corebanking/deposits/v1.0/customers/{customerNumber}")
+    List<CoreDepositDTO> getDepositsForCustomer(@PathVariable("customerNumber") String customerNumber);
+}

--- a/src/main/java/com/arch/deposit/core/CoreDepositDTO.java
+++ b/src/main/java/com/arch/deposit/core/CoreDepositDTO.java
@@ -1,0 +1,36 @@
+package com.arch.deposit.core;
+
+import lombok.Data;
+
+/**
+ * DTO representing a deposit account returned from the core banking system.
+ */
+@Data
+public class CoreDepositDTO {
+    private String depositNumber;
+    private String mainCustomerNumber;
+    private String depositTitle;
+    private String depositTypeNumber;
+    private String depositTypeTitle;
+    private String depositState;
+    private String currencyName;
+    private String currencySwiftCode;
+    private String withdrawRight;
+    private String branchCode;
+    private String depositIban;
+    private String availableAmount;
+    private String openingDate;
+    private String portion;
+    private String isSpecial;
+    private String fullName;
+    private String individualOrSharedDeposit;
+    private String actualAmount;
+    private String depositRight;
+    private String englishIndividualOrSharedDeposit;
+    private String depositIdentity;
+    private String depositIdentityCode;
+    private String withdrawRightWithCheque;
+    private String depositTypeTreeRoot;
+    private String depositTypeTreeRootCode;
+}
+

--- a/src/main/java/com/arch/deposit/core/CoreDepositTypeDTO.java
+++ b/src/main/java/com/arch/deposit/core/CoreDepositTypeDTO.java
@@ -1,0 +1,6 @@
+package com.arch.deposit.core;
+
+import java.util.UUID;
+
+/** DTO representing a deposit type returned by the core banking service. */
+public record CoreDepositTypeDTO(UUID id, String name, String description) {}

--- a/src/main/java/com/arch/deposit/deposittype/DepositType.java
+++ b/src/main/java/com/arch/deposit/deposittype/DepositType.java
@@ -1,0 +1,33 @@
+package com.arch.deposit.deposittype;
+
+import java.util.UUID;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+/**
+ * JPA entity representing a selectable type of deposit.
+ * The same entity is used for both reading and writing.
+ */
+@Entity
+@Table(name = "\"deposit\"")
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class DepositType {
+
+    @Id
+    @Column(name = "id", updatable = false, nullable = false, unique = true)
+    private UUID id;
+
+    private String name;
+    private String description;
+}
+

--- a/src/main/java/com/arch/deposit/deposittype/DepositTypeRepository.java
+++ b/src/main/java/com/arch/deposit/deposittype/DepositTypeRepository.java
@@ -1,0 +1,13 @@
+package com.arch.deposit.deposittype;
+
+import java.util.Optional;
+import java.util.UUID;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+/** Repository for available deposit types. */
+public interface DepositTypeRepository extends JpaRepository<DepositType, UUID> {
+
+    Optional<DepositType> findByName(String name);
+}
+

--- a/src/main/java/com/arch/deposit/deposittype/DepositTypeSyncService.java
+++ b/src/main/java/com/arch/deposit/deposittype/DepositTypeSyncService.java
@@ -1,0 +1,52 @@
+package com.arch.deposit.deposittype;
+
+import static java.util.Objects.requireNonNull;
+
+import java.util.List;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.arch.deposit.core.CoreClient;
+import com.arch.deposit.core.CoreDepositTypeDTO;
+
+import lombok.RequiredArgsConstructor;
+
+/**
+ * Synchronizes deposit types from the core banking system and stores them
+ * locally for faster access. The name acts as the unique key.
+ */
+@Service
+@RequiredArgsConstructor
+public class DepositTypeSyncService {
+
+    private final CoreClient coreClient;
+    private final DepositTypeRepository repository;
+
+    /**
+     * Fetch types from Core, upsert by name, and return all stored types.
+     */
+    @Transactional
+    public List<DepositType> syncAndReturnAll() {
+        List<CoreDepositTypeDTO> dtos = requireNonNull(coreClient.getDepositTypes(), "Core returned null");
+
+        for (CoreDepositTypeDTO dto : dtos) {
+            if (dto.name() == null || dto.name().isBlank()) {
+                continue;
+            }
+            String name = dto.name().trim();
+            DepositType existing = repository.findByName(name).orElse(null);
+            if (existing == null) {
+                DepositType entity = DepositType.builder()
+                        .name(name)
+                        .description(dto.description())
+                        .build();
+                repository.save(entity);
+            } else {
+                existing.setDescription(dto.description());
+                repository.save(existing);
+            }
+        }
+        return repository.findAll();
+    }
+}

--- a/src/main/java/com/arch/deposit/event/DepositOpeningStartedEvent.java
+++ b/src/main/java/com/arch/deposit/event/DepositOpeningStartedEvent.java
@@ -1,0 +1,8 @@
+package com.arch.deposit.event;
+
+/** Event emitted when the deposit opening is started. */
+public record DepositOpeningStartedEvent(
+        String depositId,
+        String userId
+) {}
+

--- a/src/main/java/com/arch/deposit/event/DepositTypeSelectedEvent.java
+++ b/src/main/java/com/arch/deposit/event/DepositTypeSelectedEvent.java
@@ -1,0 +1,10 @@
+package com.arch.deposit.event;
+
+import java.util.UUID;
+
+/** Event emitted when a user selects a deposit type. */
+public record DepositTypeSelectedEvent(
+        String depositId,
+        UUID depositTypeId
+) {}
+

--- a/src/main/java/com/arch/deposit/service/DepositService.java
+++ b/src/main/java/com/arch/deposit/service/DepositService.java
@@ -1,0 +1,70 @@
+package com.arch.deposit.service;
+
+import java.util.Map;
+import java.util.UUID;
+
+import org.axonframework.commandhandling.gateway.CommandGateway;
+import org.springframework.stereotype.Service;
+
+import com.arch.deposit.command.SelectDepositTypeCommand;
+import com.arch.deposit.command.StartDepositOpeningCommand;
+
+import io.camunda.zeebe.client.ZeebeClient;
+
+/**
+ * Application service orchestrating commands to Axon and messages to Camunda.
+ */
+@Service
+public class DepositService {
+
+    private final CommandGateway commandGateway;
+    private final ZeebeClient zeebeClient;
+
+    public DepositService(CommandGateway commandGateway,
+                          ZeebeClient zeebeClient) {
+        this.commandGateway = commandGateway;
+        this.zeebeClient = zeebeClient;
+    }
+
+    /**
+     * Starts the flow by creating the deposit aggregate and launching the BPMN
+     * process instance.
+     *
+     * @return the generated deposit identifier
+     */
+    public String startDepositOpening(String userId) {
+        String depositId = UUID.randomUUID().toString();
+
+        commandGateway.sendAndWait(new StartDepositOpeningCommand(depositId, userId));
+
+        zeebeClient.newCreateInstanceCommand()
+                .bpmnProcessId("Process_182eqvi")
+                .latestVersion()
+                .variables(Map.of("userID", userId, "depositId", depositId))
+                .send()
+                .join();
+
+        // Advance the workflow past the first catch event
+        zeebeClient.newPublishMessageCommand()
+                .messageName("start-deposit-opening")
+                .correlationKey(depositId)
+                .variables(Map.of("userID", userId, "depositId", depositId))
+                .send()
+                .join();
+
+        return depositId;
+    }
+
+    /** Second step: user chooses a deposit type. */
+    public void selectDepositType(String userId, String depositId, UUID depositTypeId) {
+        commandGateway.sendAndWait(new SelectDepositTypeCommand(depositId, depositTypeId));
+
+        zeebeClient.newPublishMessageCommand()
+                .messageName("select-deposit-type")
+                .correlationKey(depositId)
+                .variables(Map.of("depositId", depositId, "depositTypeId", depositTypeId.toString()))
+                .send()
+                .join();
+    }
+}
+

--- a/src/main/java/com/arch/deposit/worker/DisplayDepositsWorker.java
+++ b/src/main/java/com/arch/deposit/worker/DisplayDepositsWorker.java
@@ -1,0 +1,31 @@
+package com.arch.deposit.worker;
+
+import java.util.Map;
+
+import org.springframework.stereotype.Component;
+
+import com.arch.deposit.account.DepositRepository;
+
+import io.camunda.zeebe.client.api.response.ActivatedJob;
+import io.camunda.zeebe.spring.client.annotation.JobWorker;
+
+/**
+ * Worker invoked by the BPMN service task "Display user deposits". It returns
+ * the user's deposit accounts from the local database for presentation.
+ */
+@Component
+public class DisplayDepositsWorker {
+
+    private final DepositRepository repository;
+
+    public DisplayDepositsWorker(DepositRepository repository) {
+        this.repository = repository;
+    }
+
+    @JobWorker(type = "Display user deposits")
+    public Map<String, Object> handle(final ActivatedJob job) {
+        String userId = (String) job.getVariablesAsMap().get("userId");
+        return Map.of("deposits", repository.findByMainCustomerNumber(userId));
+    }
+}
+

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,1 +1,17 @@
 spring.application.name=deposit
+
+# In-memory H2 database for projections and deposit types
+spring.datasource.url=jdbc:h2:mem:deposit;DB_CLOSE_DELAY=-1
+spring.datasource.driverClassName=org.h2.Driver
+spring.jpa.hibernate.ddl-auto=update
+spring.h2.console.enabled=true
+
+# Axon without AxonServer
+axon.axonserver.enabled=false
+
+# Zeebe connection (adjust if necessary)
+zeebe.client.gateway-address=127.0.0.1:26500
+zeebe.client.plaintext=true
+
+# Core banking service base URL for deposit types
+core.service.url=http://192.168.179.20:8290

--- a/src/main/resources/deposit-opening.bpmn
+++ b/src/main/resources/deposit-opening.bpmn
@@ -1,0 +1,69 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL"
+  xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI"
+  xmlns:dc="http://www.omg.org/spec/DD/20100524/DC"
+  xmlns:di="http://www.omg.org/spec/DD/20100524/DI"
+  xmlns:zeebe="http://camunda.org/schema/zeebe/1.0"
+  id="Definitions_1" targetNamespace="http://bpmn.io/schema/bpmn">
+  <bpmn:process id="Process_182eqvi" isExecutable="true">
+    <bpmn:startEvent id="start">
+      <bpmn:outgoing>flow_start_to_startOpening</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:intermediateCatchEvent id="startOpening" name="Start deposit opening">
+      <bpmn:incoming>flow_start_to_startOpening</bpmn:incoming>
+      <bpmn:outgoing>flow_startOpening_to_displayTypes</bpmn:outgoing>
+      <bpmn:messageEventDefinition messageRef="msg_start_opening" />
+    </bpmn:intermediateCatchEvent>
+    <bpmn:serviceTask id="displayTypes" name="Display user deposits for deposit selection">
+      <bpmn:extensionElements>
+        <zeebe:taskDefinition type="Display user deposits" />
+      </bpmn:extensionElements>
+      <bpmn:incoming>flow_startOpening_to_displayTypes</bpmn:incoming>
+      <bpmn:outgoing>flow_displayTypes_to_selectType</bpmn:outgoing>
+    </bpmn:serviceTask>
+    <bpmn:intermediateCatchEvent id="selectType" name="select deposit type">
+      <bpmn:incoming>flow_displayTypes_to_selectType</bpmn:incoming>
+      <bpmn:outgoing>flow_selectType_to_acceptRules</bpmn:outgoing>
+      <bpmn:messageEventDefinition messageRef="msg_select_type" />
+    </bpmn:intermediateCatchEvent>
+    <bpmn:intermediateCatchEvent id="acceptRules" name="Acceptance of the rules for opening a term deposit">
+      <bpmn:incoming>flow_selectType_to_acceptRules</bpmn:incoming>
+      <bpmn:outgoing>flow_acceptRules_to_continue</bpmn:outgoing>
+      <bpmn:messageEventDefinition messageRef="msg_accept_rules" />
+    </bpmn:intermediateCatchEvent>
+    <bpmn:intermediateCatchEvent id="continueEvent" name="continue">
+      <bpmn:incoming>flow_acceptRules_to_continue</bpmn:incoming>
+      <bpmn:outgoing>flow_continue_to_end</bpmn:outgoing>
+      <bpmn:messageEventDefinition messageRef="msg_continue" />
+    </bpmn:intermediateCatchEvent>
+    <bpmn:endEvent id="end">
+      <bpmn:incoming>flow_continue_to_end</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="flow_start_to_startOpening" sourceRef="start" targetRef="startOpening" />
+    <bpmn:sequenceFlow id="flow_startOpening_to_displayTypes" sourceRef="startOpening" targetRef="displayTypes" />
+    <bpmn:sequenceFlow id="flow_displayTypes_to_selectType" sourceRef="displayTypes" targetRef="selectType" />
+    <bpmn:sequenceFlow id="flow_selectType_to_acceptRules" sourceRef="selectType" targetRef="acceptRules" />
+    <bpmn:sequenceFlow id="flow_acceptRules_to_continue" sourceRef="acceptRules" targetRef="continueEvent" />
+    <bpmn:sequenceFlow id="flow_continue_to_end" sourceRef="continueEvent" targetRef="end" />
+  </bpmn:process>
+  <bpmn:message id="msg_start_opening" name="start-deposit-opening">
+    <bpmn:extensionElements>
+      <zeebe:subscription correlationKey="=depositId" />
+    </bpmn:extensionElements>
+  </bpmn:message>
+  <bpmn:message id="msg_select_type" name="select-deposit-type">
+    <bpmn:extensionElements>
+      <zeebe:subscription correlationKey="=depositId" />
+    </bpmn:extensionElements>
+  </bpmn:message>
+  <bpmn:message id="msg_accept_rules" name="accept-rules">
+    <bpmn:extensionElements>
+      <zeebe:subscription correlationKey="=depositId" />
+    </bpmn:extensionElements>
+  </bpmn:message>
+  <bpmn:message id="msg_continue" name="continue">
+    <bpmn:extensionElements>
+      <zeebe:subscription correlationKey="=depositId" />
+    </bpmn:extensionElements>
+  </bpmn:message>
+</bpmn:definitions>


### PR DESCRIPTION
## Summary
- use `depositId` as Zeebe message correlation key
- automatically publish initial `start-deposit-opening` message after creating instance
- align worker type with BPMN service task
- persist user deposit accounts fetched from core banking service
- expose endpoint to refresh and return a user's deposits
- capture additional core banking fields when storing deposits locally
- configure Maven compiler to process Lombok annotations for builders and constructors
- synchronize deposit types from core service by name and return refreshed list

## Testing
- `mvn -q -e -DskipTests compile` *(fails: Non-resolvable parent POM due to network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68bbf8f9e27c832698e27ef2d653dec2